### PR TITLE
Add quiz text converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,14 @@
 
 Minimal prototype implementing instructions from `llm_pop_quiz_bench_python_build_spec.md`.
 
-Use `python -m llm_pop_quiz_bench.cli.main quiz:demo` after installing dependencies.
+After installing dependencies you can run the demo quiz:
+
+```bash
+python -m llm_pop_quiz_bench.cli.main quiz:demo
+```
+
+To convert a raw quiz text file to YAML using OpenAI, run:
+
+```bash
+python -m llm_pop_quiz_bench.cli.main quiz:convert path/to/quiz.txt
+```

--- a/docs/QUIZ_YAML_SPEC.md
+++ b/docs/QUIZ_YAML_SPEC.md
@@ -1,0 +1,30 @@
+# Quiz YAML Format
+
+This project stores each quiz definition in a YAML file. The expected schema is inspired by `quizzes/sample_ninja_turtles.yaml` and the build specification. A quiz file contains the following top-level keys:
+
+- `id` – a slug style identifier for the quiz.
+- `title` – the human readable quiz title.
+- `source` – an object with `publication` and `url` fields describing where the quiz came from.
+- `notes` – freeform notes about usage or licensing.
+- `questions` – list of question objects.
+- `outcomes` – optional list of scoring rules.
+
+Each question entry has:
+
+- `id` – unique question identifier.
+- `text` – question text.
+- `options` – list of answer options. Each option may include:
+  - `id` – letter or short identifier.
+  - `text` – the option text.
+  - `tags` – optional list of category tags.
+  - `score` – optional numeric value used by some scoring rules.
+
+An outcome entry describes how to infer the final result. Common `condition` keys are:
+
+- `mostly` – the letter chosen most often.
+- `mostlyTag` – the tag that appears most often among chosen options.
+- `scoreRange` – `{ min, max }` range for the summed option scores.
+
+The `result` field is freeform text shown when the condition is met. Only the first matching rule is applied.
+
+This format is flexible enough for most magazine-style personality quizzes and is what the CLI expects when running benchmarks.

--- a/llm_pop_quiz_bench/cli/main.py
+++ b/llm_pop_quiz_bench/cli/main.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import uuid
 from pathlib import Path
-from typing import List
 
 import typer
-import yaml
 
 from ..adapters.anthropic_adapter import AnthropicAdapter
 from ..adapters.openai_adapter import OpenAIAdapter
+from ..core.quiz_converter import text_to_yaml
 from ..core.runner import run_sync
 
 app = typer.Typer()
@@ -18,7 +17,7 @@ app = typer.Typer()
 def quiz_run(quiz: Path, models: str = "openai:gpt-4o,anthropic:claude-3-5-sonnet") -> None:
     run_id = uuid.uuid4().hex
     adapters = []
-    for m in models.split(','):
+    for m in models.split(","):
         provider, model = m.split(":", 1)
         if provider == "openai":
             adapters.append(OpenAIAdapter(model=model, api_key_env="OPENAI_API_KEY"))
@@ -31,6 +30,16 @@ def quiz_run(quiz: Path, models: str = "openai:gpt-4o,anthropic:claude-3-5-sonne
 @app.command("quiz:demo")
 def quiz_demo() -> None:
     quiz_run(Path("quizzes/sample_ninja_turtles.yaml"))
+
+
+@app.command("quiz:convert")
+def quiz_convert(text_file: Path, model: str = "gpt-4o") -> None:
+    """Convert a raw quiz text file to YAML using OpenAI."""
+    text = text_file.read_text(encoding="utf-8")
+    yaml_text = text_to_yaml(text, model=model)
+    out_path = text_file.with_suffix(".yaml")
+    out_path.write_text(yaml_text, encoding="utf-8")
+    typer.echo(f"YAML written to {out_path}")
 
 
 if __name__ == "__main__":

--- a/llm_pop_quiz_bench/core/quiz_converter.py
+++ b/llm_pop_quiz_bench/core/quiz_converter.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+
+import openai
+
+PROMPT = (
+    "You convert magazine-style quizzes to YAML. "
+    "Use keys: id, title, source{publication,url}, notes, questions, outcomes. "
+    "Each question has id, text and options with id, text, optional tags or score."
+    "Outcome conditions may use mostly, mostlyTag or scoreRange. "
+    "Return only valid YAML."
+)
+
+
+def text_to_yaml(text: str, model: str = "gpt-4o", api_key_env: str = "OPENAI_API_KEY") -> str:
+    api_key = os.environ.get(api_key_env)
+    if not api_key:
+        raise RuntimeError(f"Missing {api_key_env} environment variable")
+    client = openai.OpenAI(api_key=api_key)
+    messages = [
+        {"role": "system", "content": PROMPT},
+        {"role": "user", "content": text},
+    ]
+    resp = client.chat.completions.create(model=model, messages=messages, temperature=0)
+    return resp.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- document the quiz YAML format
- add a small helper to convert raw quiz text to YAML with OpenAI
- expose the new command `quiz:convert` via the CLI
- update README with usage instructions

## Testing
- `ruff check .` *(fails: many style violations)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885911a95b883288d2323c0f529c072