### PR TITLE
Add proxy support for OpenAI calls

### DIFF
--- a/llm_pop_quiz_bench/adapters/openai_adapter.py
+++ b/llm_pop_quiz_bench/adapters/openai_adapter.py
@@ -16,9 +16,14 @@ class OpenAIAdapter:
     def __init__(self, model: str, api_key_env: str) -> None:
         self.model = model
         self.api_key = os.environ.get(api_key_env, "")
-        self.client = httpx.AsyncClient(base_url="https://api.openai.com/v1")
+        proxy = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
+        self.client = httpx.AsyncClient(
+            base_url="https://api.openai.com/v1", proxies=proxy if proxy else None
+        )
 
-    async def send(self, messages: List[Dict[str, str]], params: Dict | None = None) -> ChatResponse:
+    async def send(
+        self, messages: List[Dict[str, str]], params: Dict | None = None
+    ) -> ChatResponse:
         headers = {"Authorization": f"Bearer {self.api_key}"}
         payload = {
             "model": self.model,
@@ -27,13 +32,19 @@ class OpenAIAdapter:
         if params:
             payload.update(params)
         start = time.perf_counter()
-        async for attempt in AsyncRetrying(stop=stop_after_attempt(3), wait=wait_exponential(min=1, max=4)):
+        async for attempt in AsyncRetrying(
+            stop=stop_after_attempt(3), wait=wait_exponential(min=1, max=4)
+        ):
             with attempt:
-                resp = await self.client.post("/chat/completions", json=payload, headers=headers, timeout=30)
+                resp = await self.client.post(
+                    "/chat/completions", json=payload, headers=headers, timeout=30
+                )
                 resp.raise_for_status()
         latency_ms = int((time.perf_counter() - start) * 1000)
         data = resp.json()
         text = data["choices"][0]["message"]["content"]
         tokens_in = data.get("usage", {}).get("prompt_tokens")
         tokens_out = data.get("usage", {}).get("completion_tokens")
-        return ChatResponse(text=text, tokens_in=tokens_in, tokens_out=tokens_out, latency_ms=latency_ms)
+        return ChatResponse(
+            text=text, tokens_in=tokens_in, tokens_out=tokens_out, latency_ms=latency_ms
+        )

--- a/llm_pop_quiz_bench/core/quiz_converter.py
+++ b/llm_pop_quiz_bench/core/quiz_converter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 
+import httpx
 import openai
 
 PROMPT = (
@@ -17,7 +18,9 @@ def text_to_yaml(text: str, model: str = "gpt-4o", api_key_env: str = "OPENAI_AP
     api_key = os.environ.get(api_key_env)
     if not api_key:
         raise RuntimeError(f"Missing {api_key_env} environment variable")
-    client = openai.OpenAI(api_key=api_key)
+    proxy = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
+    http_client = httpx.Client(proxies=proxy) if proxy else None
+    client = openai.OpenAI(api_key=api_key, http_client=http_client)
     messages = [
         {"role": "system", "content": PROMPT},
         {"role": "user", "content": text},


### PR DESCRIPTION
## Summary
- use httpx client with proxy when converting quizzes with OpenAI
- enable proxy configuration for OpenAIAdapter

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688593949b988328b3bba5d0843aa1c8