### PR TITLE
Add Markdown and CSV reporting with charts

### DIFF
--- a/llm_pop_quiz_bench/cli/main.py
+++ b/llm_pop_quiz_bench/cli/main.py
@@ -9,6 +9,7 @@ from ..adapters.anthropic_adapter import AnthropicAdapter
 from ..adapters.openai_adapter import OpenAIAdapter
 from ..core.quiz_converter import text_to_yaml
 from ..core.runner import run_sync
+from ..core import reporter
 
 app = typer.Typer()
 
@@ -40,6 +41,12 @@ def quiz_convert(text_file: Path, model: str = "gpt-4o") -> None:
     out_path = text_file.with_suffix(".yaml")
     out_path.write_text(yaml_text, encoding="utf-8")
     typer.echo(f"YAML written to {out_path}")
+
+
+@app.command("quiz:report")
+def quiz_report(run_id: str, results_dir: Path = Path("results")) -> None:
+    """Generate Markdown and CSV summaries for a run."""
+    reporter.generate_markdown_report(run_id, results_dir)
 
 
 if __name__ == "__main__":

--- a/llm_pop_quiz_bench/core/reporter.py
+++ b/llm_pop_quiz_bench/core/reporter.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable, Tuple
+from typing import Iterable, Tuple, List, Dict
 
 import pandas as pd
+import matplotlib.pyplot as plt
+import yaml
 
-from .store import write_csv
+from .store import write_csv, read_jsonl
+from .scorer import compute_choice_histogram, infer_mostly_letter, infer_mostly_tag
 
 
 def render_outcomes_table(quiz_title: str, outcomes: Iterable[Tuple[str, str]]) -> str:
@@ -18,3 +21,114 @@ def render_outcomes_table(quiz_title: str, outcomes: Iterable[Tuple[str, str]]) 
 def write_summary_csv(path: Path, rows: Iterable[dict]) -> None:
     df = pd.DataFrame(rows)
     write_csv(path, df.to_dict(orient="records"))
+
+
+def load_results(run_id: str, results_dir: Path) -> pd.DataFrame:
+    rows: List[Dict] = []
+    for path in (results_dir / "raw").glob(f"{run_id}.*.jsonl"):
+        parts = path.stem.split(".")
+        if len(parts) < 3:
+            continue
+        _, quiz_id, model_id = parts
+        recs = read_jsonl(path)
+        for rec in recs:
+            rec.update({"run_id": run_id, "quiz_id": quiz_id, "model_id": model_id})
+            rows.append(rec)
+    return pd.DataFrame(rows)
+
+
+def render_question_table(df: pd.DataFrame) -> str:
+    pivot = df.pivot(index="question_id", columns="model_id", values="choice")
+    cols = list(pivot.columns)
+    lines = ["| Question | " + " | ".join(cols) + " |"]
+    lines.append("|" + "-" * (len(lines[0]) - 2) + "|")
+    for qid, row in pivot.iterrows():
+        vals = [str(row.get(c, "")) for c in cols]
+        lines.append("| " + qid + " | " + " | ".join(vals) + " |")
+    return "\n".join(lines)
+
+
+def compute_model_outcomes(df: pd.DataFrame, quiz_def: dict) -> List[Dict[str, str]]:
+    lookup = {}
+    for q in quiz_def.get("questions", []):
+        for opt in q.get("options", []):
+            lookup[(q["id"], opt["id"])] = opt
+
+    outcomes = []
+    for model_id, g in df.groupby("model_id"):
+        letter_hist = g["choice"].value_counts().to_dict()
+        tag_hist: Dict[str, int] = {}
+        score = 0
+        for _, row in g.iterrows():
+            opt = lookup.get((row["question_id"], row["choice"]))
+            if not opt:
+                continue
+            for t in opt.get("tags", []):
+                tag_hist[t] = tag_hist.get(t, 0) + 1
+            if "score" in opt and opt["score"] is not None:
+                score += opt["score"]
+        result = ""
+        for rule in quiz_def.get("outcomes", []):
+            cond = rule.get("condition", {})
+            if "mostly" in cond:
+                if letter_hist and infer_mostly_letter(letter_hist) == cond["mostly"]:
+                    result = rule["result"]
+                    break
+            if "mostlyTag" in cond:
+                if tag_hist and infer_mostly_tag(tag_hist) == cond["mostlyTag"]:
+                    result = rule["result"]
+                    break
+            if "scoreRange" in cond:
+                rng = cond["scoreRange"]
+                if rng.get("min", 0) <= score <= rng.get("max", score):
+                    result = rule["result"]
+                    break
+        outcomes.append({"model_id": model_id, "outcome": result})
+    return outcomes
+
+
+def generate_charts(df: pd.DataFrame, out_dir: Path, run_id: str, quiz_id: str) -> Dict[str, Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths: Dict[str, Path] = {}
+    for model_id, g in df.groupby("model_id"):
+        hist = g["choice"].value_counts().sort_index()
+        fig, ax = plt.subplots()
+        hist.plot.bar(ax=ax)
+        ax.set_xlabel("Choice")
+        ax.set_ylabel("Count")
+        ax.set_title(f"{model_id} choices")
+        img_path = out_dir / f"{run_id}.{quiz_id}.{model_id}.png"
+        fig.tight_layout()
+        fig.savefig(img_path)
+        plt.close(fig)
+        paths[model_id] = img_path
+    return paths
+
+
+def generate_markdown_report(run_id: str, results_dir: Path) -> None:
+    df = load_results(run_id, results_dir)
+    if df.empty:
+        raise ValueError(f"No results for run {run_id}")
+    summary_dir = results_dir / "summary"
+    summary_dir.mkdir(parents=True, exist_ok=True)
+    write_summary_csv(summary_dir / f"{run_id}.csv", df.to_dict(orient="records"))
+
+    for quiz_id, qdf in df.groupby("quiz_id"):
+        quiz_path = Path("quizzes") / f"{quiz_id}.yaml"
+        quiz_def = yaml.safe_load(quiz_path.read_text(encoding="utf-8"))
+        outcomes = compute_model_outcomes(qdf, quiz_def)
+        md_lines = [f"# {quiz_def['title']}", f"Source: {quiz_def['source']['url']}"]
+        md_lines.append("\n## Outcomes")
+        md_lines.append(render_outcomes_table(quiz_def["title"], [(o["model_id"], o["outcome"]) for o in outcomes]))
+        md_lines.append("\n## Choices by Question")
+        md_lines.append(render_question_table(qdf))
+
+        chart_paths = generate_charts(qdf, results_dir / "charts", run_id, quiz_id)
+        for path in chart_paths.values():
+            rel = path.relative_to(summary_dir.parent)
+            md_lines.append(f"\n![{path.stem}]({rel.as_posix()})")
+
+        md_content = "\n".join(md_lines)
+        md_file = summary_dir / f"{run_id}.{quiz_id}.md"
+        md_file.write_text(md_content, encoding="utf-8")
+

--- a/llm_pop_quiz_bench/core/store.py
+++ b/llm_pop_quiz_bench/core/store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import csv
 import json
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, List
 
 
 def write_jsonl(path: Path, records: Iterable[dict]) -> None:
@@ -17,6 +17,14 @@ def append_jsonl(path: Path, record: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def read_jsonl(path: Path) -> List[dict]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
 
 
 def write_csv(path: Path, rows: Iterable[dict]) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ anthropic
 google-generativeai
 cohere
 ai21
+matplotlib
 pytest
 pytest-asyncio
 respx


### PR DESCRIPTION
## Summary
- expand reporter to load quiz results, compute outcomes and charts
- export CSV and Markdown with embedded images
- support reading JSONL data
- expose `quiz:report` command
- add `matplotlib` dependency

## Testing
- `ruff check .` *(fails: Import block is un-sorted or un-formatted)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885950c62f8832884dd1adbe594dc78