### PR TITLE
Add mock results output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ python -m llm_pop_quiz_bench.cli.main quiz:convert path/to/quiz.txt
 ```
 
 Set `LLM_POP_QUIZ_ENV=mock` to use internal mock adapters instead of real API
-calls. The default is `real`.
+calls. When running in mock mode, outputs are written to `results/mock/` instead
+of `results/`. The default environment is `real`.
 

--- a/llm_pop_quiz_bench/cli/main.py
+++ b/llm_pop_quiz_bench/cli/main.py
@@ -23,6 +23,7 @@ def quiz_run(quiz: Path, models: str = "openai:gpt-4o,anthropic:claude-3-5-sonne
     run_id = uuid.uuid4().hex
     adapters = []
     use_mocks = os.environ.get("LLM_POP_QUIZ_ENV", "real").lower() == "mock"
+    results_dir = Path("results/mock" if use_mocks else "results")
     for m in models.split(","):
         provider, model = m.split(":", 1)
         if use_mocks:
@@ -36,7 +37,7 @@ def quiz_run(quiz: Path, models: str = "openai:gpt-4o,anthropic:claude-3-5-sonne
         quiz_path=quiz,
         adapters=adapters,
         run_id=run_id,
-        results_dir=Path("results"),
+        results_dir=results_dir,
     )
     typer.echo(f"Run ID: {run_id}")
 
@@ -59,6 +60,11 @@ def quiz_convert(text_file: Path, model: str = "gpt-4o") -> None:
 @app.command("quiz:report")
 def quiz_report(run_id: str, results_dir: Path = Path("results")) -> None:
     """Generate Markdown and CSV summaries for a run."""
+    if (
+        results_dir == Path("results")
+        and os.environ.get("LLM_POP_QUIZ_ENV", "real").lower() == "mock"
+    ):
+        results_dir = Path("results/mock")
     reporter.generate_markdown_report(run_id, results_dir)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from llm_pop_quiz_bench.cli.main import quiz_run
+
+
+def test_cli_mock_results_dir(tmp_path, monkeypatch):
+    quiz = {
+        "id": "mock-quiz",
+        "title": "Mock Quiz",
+        "source": {"publication": "X", "url": "https://x"},
+        "questions": [
+            {
+                "id": "Q1",
+                "text": "Pick one:",
+                "options": [
+                    {"id": "A", "text": "A"},
+                    {"id": "B", "text": "B"},
+                    {"id": "C", "text": "C"},
+                ],
+            }
+        ],
+    }
+    quiz_path = tmp_path / "quiz.yaml"
+    quiz_path.write_text(yaml.safe_dump(quiz), encoding="utf-8")
+
+    monkeypatch.setenv("LLM_POP_QUIZ_ENV", "mock")
+    monkeypatch.chdir(tmp_path)
+
+    quiz_run(quiz_path)
+
+    raw_dir = tmp_path / "results" / "mock" / "raw"
+    assert any(raw_dir.glob("*.jsonl"))


### PR DESCRIPTION
## Summary
- when in mock mode output to `results/mock` instead of `results`
- update CLI to read mock results in `quiz:report`
- document the new location in README
- test CLI behaviour when `LLM_POP_QUIZ_ENV=mock`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885fd3a0c308328ad3e312cd80ee18c