### PR TITLE
Aggregate model results into a single JSON file

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,9 +34,9 @@ def test_cli_mock_results_dir(tmp_path, monkeypatch):
     quiz_run(quiz_path)
 
     raw_dir = tmp_path / "results" / "mock" / "raw"
-    # Check for per-run subfolders containing jsonl files
+    # Check for per-run subfolders containing result files
     run_dirs = [d for d in raw_dir.iterdir() if d.is_dir()]
     assert len(run_dirs) >= 1, "Expected at least one run directory"
-    # Check that the run directory contains jsonl files
+    # Check that the run directory contains json files
     run_dir = run_dirs[0]
-    assert any(run_dir.glob("*.jsonl")), f"Expected jsonl files in {run_dir}"
+    assert any(run_dir.glob("*.json")), f"Expected json files in {run_dir}"

--- a/tests/test_runner_mocked.py
+++ b/tests/test_runner_mocked.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import sys
 from pathlib import Path
 
@@ -36,8 +37,10 @@ async def _run(tmp_path: Path):
     # Check for per-run subfolder structure
     run_dir = out_dir / "raw" / "test-run"
     assert run_dir.exists(), "Expected per-run subfolder to exist"
-    raw_files = list(run_dir.glob("*.jsonl"))
-    assert raw_files, "Expected jsonl files in per-run subfolder"
+    raw_files = list(run_dir.glob("*.json"))
+    assert raw_files, "Expected json files in per-run subfolder"
+    data = json.loads(raw_files[0].read_text(encoding="utf-8"))
+    assert "results" in data and data["results"], "Results should contain model entries"
 
 
 def test_runner_mocked(tmp_path):


### PR DESCRIPTION
## Summary
- store quiz run outputs for all models in a single aggregated JSON file
- teach reporter to parse combined JSON while keeping backward compatibility
- update tests for new combined results format

## Testing
- `ruff check .` *(fails: import sorting and typing style issues)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d521304048328ab0b29221d18188c