### PR TITLE
Include option text in AI reasoning section

### DIFF
--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -2,6 +2,8 @@ import pathlib
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import pandas as pd
+
 from llm_pop_quiz_bench.core import reporter
 
 
@@ -11,3 +13,31 @@ def test_markdown_table_renders():
         outcomes=[("openai:gpt-4o", "Leonardo"), ("anthropic:claude-3-5-sonnet", "Donatello")],
     )
     assert "openai:gpt-4o" in md
+
+
+def test_ai_reasoning_includes_answer_text():
+    df = pd.DataFrame(
+        [
+            {
+                "question_id": "Q1",
+                "model_id": "openai",
+                "choice": "B",
+                "reason": "Because it's refreshing",
+                "additional_thoughts": "",
+            }
+        ]
+    )
+    quiz_def = {
+        "questions": [
+            {
+                "id": "Q1",
+                "text": "Your drink of choice:",
+                "options": [
+                    {"id": "A", "text": "Coffee"},
+                    {"id": "B", "text": "Water with lemon"},
+                ],
+            }
+        ]
+    }
+    md = reporter.render_ai_reasoning_section(df, quiz_def)
+    assert "B: Water with lemon" in md


### PR DESCRIPTION
## Summary
- Enhance AI reasoning section to include answer text alongside selected option letters.
- Add regression test ensuring reasoning section outputs letter and answer text.

## Testing
- `ruff check .` (fails: unrecognized subcommand '.'? oh; we attempted; then ruff check outputs many lint errors)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dc3b110848328952f36b10872586f