### PR TITLE
Add quiz reprocessing and richer quiz detail preview

### DIFF
--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -92,3 +92,43 @@ def test_create_run_returns_id(client, monkeypatch):
     run_resp = client.post("/api/runs", json={"quiz_id": "mock-quiz", "models": ["openai:gpt-4o"]})
     assert run_resp.status_code == 200
     assert "run_id" in run_resp.json()
+
+
+def test_reprocess_quiz_from_raw(client, monkeypatch):
+    import importlib
+
+    api_app = importlib.import_module("llm_pop_quiz_bench.api.app")
+
+    base_quiz_def = {
+        "id": "mock-quiz",
+        "title": "Mock Quiz",
+        "source": {"publication": "X", "url": "https://x"},
+        "questions": [
+            {
+                "id": "Q1",
+                "text": "Pick one:",
+                "options": [
+                    {"id": "A", "text": "A"},
+                    {"id": "B", "text": "B"},
+                ],
+            }
+        ],
+        "outcomes": [],
+    }
+
+    monkeypatch.setattr(api_app, "convert_to_yaml", lambda **kwargs: yaml.safe_dump(base_quiz_def))
+    resp = client.post("/api/quizzes/parse", data={"text": "initial raw"})
+    assert resp.status_code == 200
+
+    def reprocess_convert_to_yaml(**kwargs):
+        assert kwargs.get("text") == "initial raw"
+        updated = dict(base_quiz_def)
+        updated["title"] = "Reprocessed Title"
+        return yaml.safe_dump(updated)
+
+    monkeypatch.setattr(api_app, "convert_to_yaml", reprocess_convert_to_yaml)
+    reprocess_resp = client.post("/api/quizzes/mock-quiz/reprocess")
+    assert reprocess_resp.status_code == 200
+    data = reprocess_resp.json()
+    assert data["quiz"]["title"] == "Reprocessed Title"
+    assert data["raw_payload"]["type"] == "text"

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -340,6 +340,44 @@ pre {
   text-align: left;
 }
 
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.meta-grid .label {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.preview-subsection {
+  display: grid;
+  gap: 8px;
+}
+
+.preview-subsection h4 {
+  margin: 0;
+}
+
+.outcome-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.yaml-preview summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.yaml-preview pre {
+  max-height: 260px;
+  overflow: auto;
+}
+
 .table th {
   color: var(--muted);
 }


### PR DESCRIPTION
## Summary
- store raw quiz payloads in SQLite, expose them via the quiz API, and add a reprocessing endpoint
- enhance the frontend quiz preview with scoring/outcome details, YAML visibility, and raw-source badges with reprocess controls
- cover the new reprocessing behavior with API smoke tests

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e4d9fc17083288cc2423f8b6e3e99)