### PR TITLE
Add raw input previews for quizzes

### DIFF
--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -119,6 +119,8 @@ def test_reprocess_quiz_from_raw(client, monkeypatch):
     monkeypatch.setattr(api_app, "convert_to_yaml", lambda **kwargs: yaml.safe_dump(base_quiz_def))
     resp = client.post("/api/quizzes/parse", data={"text": "initial raw"})
     assert resp.status_code == 200
+    parsed = resp.json()
+    assert parsed["raw_preview"]["text"] == "initial raw"
 
     def reprocess_convert_to_yaml(**kwargs):
         assert kwargs.get("text") == "initial raw"
@@ -132,3 +134,4 @@ def test_reprocess_quiz_from_raw(client, monkeypatch):
     data = reprocess_resp.json()
     assert data["quiz"]["title"] == "Reprocessed Title"
     assert data["raw_payload"]["type"] == "text"
+    assert data["raw_preview"]["text"] == "initial raw"

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -2,10 +2,12 @@ const state = {
   quiz: null,
   quizYaml: null,
   quizRawPayload: null,
+  quizRawPreview: null,
   quizzes: [],
   previewQuiz: null,
   previewQuizYaml: null,
   previewRawPayload: null,
+  previewRawPreview: null,
   models: [],
   groups: {},
   selectedModels: new Set(),
@@ -59,6 +61,7 @@ class QuizUploader extends HTMLElement {
       state.quiz = data.quiz;
       state.quizYaml = data.quiz_yaml;
       state.quizRawPayload = data.raw_payload || null;
+      state.quizRawPreview = data.raw_preview || null;
       status.textContent = `Parsed quiz: ${state.quiz.id} (saved to library)`;
       this.render();
       await refreshQuizzes();
@@ -136,6 +139,7 @@ class QuizLibrary extends HTMLElement {
       state.quiz = data.quiz;
       state.quizYaml = data.quiz_yaml || null;
       state.quizRawPayload = data.raw_payload || null;
+      state.quizRawPreview = data.raw_preview || null;
       status.textContent = `Loaded quiz: ${quizId}`;
       document.dispatchEvent(new CustomEvent("quiz:updated"));
     } catch (err) {
@@ -151,6 +155,7 @@ class QuizLibrary extends HTMLElement {
       state.previewQuiz = data.quiz;
       state.previewQuizYaml = data.quiz_yaml || null;
       state.previewRawPayload = data.raw_payload || null;
+      state.previewRawPreview = data.raw_preview || null;
       status.textContent = `Previewing: ${quizId}`;
       this.render();
     } catch (err) {
@@ -171,10 +176,12 @@ class QuizLibrary extends HTMLElement {
       state.previewQuiz = data.quiz;
       state.previewQuizYaml = data.quiz_yaml || null;
       state.previewRawPayload = data.raw_payload || null;
+      state.previewRawPreview = data.raw_preview || null;
       if (state.quiz?.id === quizId) {
         state.quiz = data.quiz;
         state.quizYaml = data.quiz_yaml || null;
         state.quizRawPayload = data.raw_payload || null;
+        state.quizRawPreview = data.raw_preview || null;
         document.dispatchEvent(new CustomEvent("quiz:updated"));
       }
       status.textContent = `Reprocessed: ${quizId}`;
@@ -229,6 +236,7 @@ class QuizLibrary extends HTMLElement {
           ${renderQuizPreview(state.previewQuiz, {
             quizYaml: state.previewQuizYaml,
             rawPayload: state.previewRawPayload,
+            rawPreview: state.previewRawPreview,
           })}
         </div>
       `
@@ -271,6 +279,7 @@ class QuizLibrary extends HTMLElement {
       state.previewQuiz = null;
       state.previewQuizYaml = null;
       state.previewRawPayload = null;
+      state.previewRawPreview = null;
       this.render();
     });
     this.querySelector("button[data-next]")?.addEventListener("click", () => {
@@ -731,7 +740,25 @@ function formatOptionDetails(option = {}) {
   return details.length ? ` <span class="status">(${details.join(" · ")})</span>` : "";
 }
 
-function renderQuizPreview(quiz, { quizYaml = null, rawPayload = null } = {}) {
+function renderRawInput(rawPreview) {
+  if (!rawPreview) {
+    return "<div class=\"status\">Raw input not available.</div>";
+  }
+  if (rawPreview.type === "text") {
+    return `<pre class="preview">${rawPreview.text || ""}</pre>`;
+  }
+  if (rawPreview.type === "image" && rawPreview.data_url) {
+    return `
+      <div class="raw-image-frame">
+        <img src="${rawPreview.data_url}" alt="Uploaded quiz image" />
+        <div class="status">${rawPreview.filename || "Uploaded image"} (${rawPreview.mime || ""})</div>
+      </div>
+    `;
+  }
+  return "<div class=\"status\">Raw input not available.</div>";
+}
+
+function renderQuizPreview(quiz, { quizYaml = null, rawPayload = null, rawPreview = null } = {}) {
   const questions = quiz.questions || [];
   const items = questions
     .map((question, index) => {
@@ -772,6 +799,15 @@ function renderQuizPreview(quiz, { quizYaml = null, rawPayload = null } = {}) {
     `
     : "";
 
+  const rawBlock = rawPayload
+    ? `
+      <details class="raw-preview">
+        <summary>View raw ${rawPreview?.type === "image" ? "image" : "text"}</summary>
+        ${renderRawInput(rawPreview)}
+      </details>
+    `
+    : "";
+
   const metaRows = [
     ["Quiz ID", quiz.id || ""],
     ["Type", getQuizType(quiz)],
@@ -799,6 +835,7 @@ function renderQuizPreview(quiz, { quizYaml = null, rawPayload = null } = {}) {
       <h4>Outcomes & scoring</h4>
       <ul class="outcome-list">${outcomes || "<li class='status'>No outcomes defined.</li>"}</ul>
     </div>
+    ${rawBlock}
     ${yamlBlock}
   `;
 }

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -368,14 +368,28 @@ pre {
   gap: 8px;
 }
 
-.yaml-preview summary {
+.yaml-preview summary,
+.raw-preview summary {
   cursor: pointer;
   font-weight: 600;
 }
 
-.yaml-preview pre {
+.yaml-preview pre,
+.raw-preview pre {
   max-height: 260px;
   overflow: auto;
+}
+
+.raw-image-frame {
+  display: grid;
+  gap: 8px;
+}
+
+.raw-image-frame img {
+  max-width: 100%;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
 }
 
 .table th {


### PR DESCRIPTION
## Summary
- expose raw quiz input previews alongside YAML responses
- display raw text or image content in the quiz preview panel with supporting styles
- cover the new raw preview payload in the API smoke test

## Testing
- python -m pytest tests/test_api_smoke.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e52c271608328a9153a6bc8d2e7bd)