### PR TITLE
Add quiz deletion endpoint and UI control

### DIFF
--- a/llm_pop_quiz_bench/core/sqlite_store.py
+++ b/llm_pop_quiz_bench/core/sqlite_store.py
@@ -295,3 +295,20 @@ def fetch_quiz_record(conn: sqlite3.Connection, quiz_id: str) -> dict | None:
         "quiz_yaml": row["quiz_yaml"],
         "raw_payload": raw_payload,
     }
+
+
+def delete_quiz(conn: sqlite3.Connection, quiz_id: str) -> list[str]:
+    run_rows = conn.execute(
+        "SELECT run_id FROM runs WHERE quiz_id = ?",
+        (quiz_id,),
+    ).fetchall()
+    run_ids = [row["run_id"] for row in run_rows]
+
+    if run_ids:
+        conn.executemany("DELETE FROM results WHERE run_id = ?", ((rid,) for rid in run_ids))
+        conn.executemany("DELETE FROM assets WHERE run_id = ?", ((rid,) for rid in run_ids))
+        conn.executemany("DELETE FROM runs WHERE run_id = ?", ((rid,) for rid in run_ids))
+
+    conn.execute("DELETE FROM quizzes WHERE quiz_id = ?", (quiz_id,))
+    conn.commit()
+    return run_ids

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -210,6 +210,12 @@ button.secondary {
   border: 1px solid var(--accent);
 }
 
+button.danger {
+  background: transparent;
+  color: #b3261e;
+  border: 1px solid #b3261e;
+}
+
 button:disabled {
   opacity: 0.6;
   cursor: not-allowed;


### PR DESCRIPTION
## Summary
- add backend support to delete quizzes along with related runs and assets
- expose quiz deletion in the library UI with confirmation and styling
- cover quiz deletion flow with API smoke test

## Testing
- pytest tests/test_api_smoke.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e57bb11988328a89869a13d20c3cb)